### PR TITLE
ci: add aggregator job named "build" to satisfy branch protection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,3 +29,17 @@ jobs:
       # Catch version/mcpName drift on every PR rather than at tag time.
       - name: Verify release metadata
         run: node scripts/verify-release.cjs
+
+  # master's branch protection requires a check named exactly "build". A matrix job
+  # can't produce one (it emits "build-and-test (18)" and friends), so this aggregator
+  # supplies it and passes only when every matrix leg succeeded. Without it, no PR is
+  # mergeable without an admin override.
+  build:
+    runs-on: ubuntu-latest
+    needs: build-and-test
+    if: always()
+    steps:
+      - name: Require all matrix jobs to have succeeded
+        run: |
+          echo "build-and-test result: ${{ needs.build-and-test.result }}"
+          test "${{ needs.build-and-test.result }}" = "success"


### PR DESCRIPTION
`master`'s branch protection requires a status check named exactly **`build`**. The CI job is a matrix, so it emits `build-and-test (18)`, `build-and-test (20)`, `build-and-test (22)` — never plain `build`.

The required check therefore **never ran and could never pass**, meaning no PR was mergeable without an admin override. That's how #25 had to land.

This adds a dependent job named `build` that succeeds only if every matrix leg succeeded. It satisfies the existing rule without weakening it and restores normal, non-admin merges.

This PR should be mergeable without `--admin` — which is the test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)