### PR TITLE
feat(release): automate the last of the manual release checklist

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,24 @@ jobs:
       - name: Publish prodlint-mcp launcher to npm
         run: npm publish ./packages/prodlint-mcp --provenance --access public
 
+      # Registry auth is OIDC too, so this needs no stored credential. Previously this
+      # step was manual and awkward: mcp-publisher's registry JWT expires within
+      # minutes of an interactive `login github`.
+      - name: Install mcp-publisher
+        env:
+          MCP_PUBLISHER_VERSION: v1.8.1
+          MCP_PUBLISHER_SHA256: a06c9096dcb9727c13555b6be26c7effa707b01f06a4c561ba7a3635443cf2cc
+        run: |
+          curl -fsSL -o mcp-publisher.tar.gz \
+            "https://github.com/modelcontextprotocol/registry/releases/download/${MCP_PUBLISHER_VERSION}/mcp-publisher_linux_amd64.tar.gz"
+          echo "${MCP_PUBLISHER_SHA256}  mcp-publisher.tar.gz" | sha256sum -c -
+          tar xzf mcp-publisher.tar.gz mcp-publisher
+
+      - name: Publish to MCP Registry
+        run: |
+          ./mcp-publisher login github-oidc
+          ./mcp-publisher publish
+
       - name: Update rolling v1 tag
         run: |
           git tag -f v1

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,9 @@ dist/
 
 # MCP registry publisher
 .mcpregistry_*
+mcp-publisher
 mcp-publisher.exe
+mcp-publisher.tar.gz
 
 # Windows artifacts
 nul

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,31 +141,45 @@ Composite action: installs Node 20, runs `npx prodlint --json`, parses JSON, pos
 
 ### Version Bump Checklist
 
-Releases are automated. `npm version patch/minor/major` fires the `version` lifecycle
-hook, which runs `scripts/sync-versions.cjs` to propagate the new version into
-`server.json` (both fields) and `packages/prodlint-mcp/package.json` (its `version` and
-its `^` dependency range on `prodlint`), then stages them into the version commit.
+A release in this repo is two commands:
 
-Pushing the resulting `vX.Y.Z` tag runs `.github/workflows/release.yml`, which verifies
-metadata, builds, tests, self-scans, and publishes **both** `prodlint` and the
-`prodlint-mcp` launcher to npm with provenance, then force-updates the rolling `v1` tag.
+```bash
+npm version patch    # or minor/major
+git push --follow-tags
+```
 
-npm auth is **trusted publishing (OIDC)** — there is no `NPM_TOKEN`. Both packages have
-`prodlint/prodlint` + `release.yml` registered as a trusted publisher on npmjs.com.
+`npm version` fires the `version` lifecycle hook, which runs `scripts/sync-versions.cjs`
+to propagate the new version into `server.json` (both fields),
+`packages/prodlint-mcp/package.json` (its `version` and its `^` range on `prodlint`),
+the `README.md` sample output, and the `tests/reporter.test.ts` fixture — then stages
+them into the version commit. The script **fails loudly** if a text anchor no longer
+matches exactly once, rather than silently skipping a file.
 
-**Still manual:**
-1. `README.md` → terminal output example (`prodlint v0.x.x`)
-2. `tests/reporter.test.ts` → `makeResult()` fixture `version: '0.x.x'`
-3. `./mcp-publisher.exe publish` (MCP registry — needs `mcp-publisher.exe login github`
-   first; the registry JWT expires within minutes, so log in immediately before)
-4. Website repo (prodlint-website): `app/components/animated-terminal.tsx`,
-   `app/layout.tsx` JSON-LD `softwareVersion`,
-   `public/.well-known/agent-card.json` → `"version"`, and the sample output in
-   `app/blog/data.ts`. Note: `app/mcp/page.tsx` no longer carries a version string.
+Pushing the `vX.Y.Z` tag runs `.github/workflows/release.yml`, which verifies metadata,
+builds, tests, self-scans, publishes **both** `prodlint` and the `prodlint-mcp` launcher
+to npm with provenance, publishes to the **MCP registry**, then force-updates the
+rolling `v1` tag.
 
-Tip: sweep both repos with `grep -rn "<old-version>"` (excluding
-node_modules/dist/package-lock/CHANGELOG) to catch stragglers. `npm run verify:release`
-checks the automated set at any time; CI runs it on every PR.
+Every credential is OIDC — there is no `NPM_TOKEN` and no stored registry JWT:
+- **npm**: trusted publishing. Both `prodlint` and `prodlint-mcp` have
+  `prodlint/prodlint` + `release.yml` registered as a trusted publisher on npmjs.com.
+- **MCP registry**: `mcp-publisher login github-oidc`. The pinned publisher tarball is
+  SHA256-verified before it runs; bump `MCP_PUBLISHER_VERSION`/`MCP_PUBLISHER_SHA256`
+  together (get the digest from the release asset's `digest` field).
+
+**Still manual — the website repo only** (prodlint-website):
+`app/components/animated-terminal.tsx`, `app/layout.tsx` JSON-LD `softwareVersion`,
+`public/.well-known/agent-card.json` → `"version"`, and the sample output in
+`app/blog/data.ts`. Note: `app/mcp/page.tsx` no longer carries a version string.
+
+Tip: sweep the website repo with `grep -rn "<old-version>"` (excluding
+node_modules/dist/package-lock/CHANGELOG). `npm run verify:release` checks this repo's
+set at any time; CI runs it on every PR.
+
+**`master` branch protection requires a check named exactly `build`.** The CI matrix
+emits `build-and-test (18|20|22)`, so `ci.yml` carries a dependent aggregator job named
+`build` purely to satisfy it. Removing that job silently makes every PR unmergeable
+without an admin override.
 
 **Do not re-add `@rollup/rollup-win32-x64-msvc` as an explicit dependency.** It was a
 workaround for an `os=linux` line in the machine's global `~/.npmrc`, which made npm skip

--- a/scripts/sync-versions.cjs
+++ b/scripts/sync-versions.cjs
@@ -38,5 +38,45 @@ if (mcp.dependencies.prodlint !== `^${version}`) {
 }
 fs.writeFileSync(mcpPath, JSON.stringify(mcp, null, 2) + '\n');
 
+// Plain-text version strings. Each pattern must match exactly once — if a file is
+// restructured so the anchor moves, fail loudly rather than silently skipping it.
+const SEMVER = /\d+\.\d+\.\d+/;
+const textTargets = [
+  {
+    file: 'README.md',
+    label: 'README sample output',
+    pattern: /^\s*prodlint v\d+\.\d+\.\d+$/m,
+  },
+  {
+    file: 'tests/reporter.test.ts',
+    label: 'reporter test fixture',
+    pattern: /^\s*version: '\d+\.\d+\.\d+',$/m,
+  },
+];
+
+for (const { file, label, pattern } of textTargets) {
+  const full = path.join(root, file);
+  const raw = fs.readFileSync(full, 'utf8');
+  const matches = raw.match(new RegExp(pattern.source, pattern.flags.replace('m', 'gm')));
+
+  if (!matches || matches.length !== 1) {
+    console.error(
+      `\n${file}: expected exactly 1 version string for "${label}", found ${matches ? matches.length : 0}.`
+    );
+    console.error('The anchor has moved — update scripts/sync-versions.cjs.');
+    process.exit(1);
+  }
+
+  // Substitute inside the matched line rather than reassembling from capture groups —
+  // replace() passes the match offset where an unused group would be, so an arity
+  // mismatch silently appends it to the version.
+  const before = matches[0];
+  const updated = raw.replace(pattern, (m) => m.replace(SEMVER, version));
+  if (updated !== raw) {
+    edits.push(`${label}: ${before.trim()} -> ${before.trim().replace(SEMVER, version)}`);
+    fs.writeFileSync(full, updated);
+  }
+}
+
 console.log(`Syncing everything to v${version}`);
 console.log(edits.length ? edits.map((e) => `  ${e}`).join('\n') : '  (already in sync)');


### PR DESCRIPTION
Follow-on to #25 and #26. Removes three of the four remaining hand-edited release steps.

## Version string sync

`scripts/sync-versions.cjs` now also rewrites the `README.md` sample output and the `tests/reporter.test.ts` fixture. Combined with what #25 added, `npm version <bump>` now propagates **every** hardcoded version string in this repo.

Each text anchor must match exactly once — if a file is restructured, the script exits non-zero rather than silently skipping it.

## MCP registry publish

Added to `release.yml` via `mcp-publisher login github-oidc`, which needs no stored credential. This step was previously manual and genuinely awkward: the registry JWT expires within minutes of an interactive login, so it had to be done immediately before publishing.

The publisher tarball is **pinned to v1.8.1 and SHA256-verified** before it runs, rather than curl'd from `latest` — the official example uses `latest`, but that's not a standard this repo should hold itself to.

## Result

A release is now:

```bash
npm version patch
git push --follow-tags
```

Every credential in the pipeline is OIDC. No `NPM_TOKEN`, no stored registry JWT. Only the separate website repo still needs hand edits.

## Note on a bug caught in testing

The text replacement substitutes inside the matched line rather than reassembling from capture groups. `String.replace` passes the match offset where an unused group would be, so an arity mismatch appends it to the version — this surfaced as `prodlint v0.9.5685` and is fixed.

Verified by simulating a real 0.9.5 → 0.9.6 bump: all six targets updated, `verify:release` passed, reporter tests passed, then reverted clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)